### PR TITLE
Set up basic Redux store with persist and auth hook

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+
+export const useAuth = () => {
+  const auth = useSelector(state => state.auth);
+
+  return {
+    user: auth.user,
+    token: auth.token,
+    isAuthenticated: auth.isAuthenticated,
+  };
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,14 +1,21 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
 import 'modern-normalize';
 import App from './components/App/App';
+import { store, persistor } from './redux/store';
 import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </PersistGate>
+    </Provider>
   </StrictMode>
 );

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,35 @@
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import authReducer from './authSlice';
+
+const persistConfig = {
+  key: 'user-token',
+  storage,
+  whitelist: ['token'],
+};
+
+const persistedAuthReducer = persistReducer(persistConfig, authReducer);
+
+export const store = configureStore({
+  reducer: {
+    auth: persistedAuthReducer,
+  },
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+});
+
+export const persistor = persistStore(store);


### PR DESCRIPTION
Pull Request додає початкову конфігурацію логіки автентифікації користувача на базі Redux Toolkit та redux-persist.

### ✅ Що реалізовано:
- Створено `redux/store.js` із persistReducer для збереження стейту `auth`
- Додано хук `useAuth` для доступу до користувача, токену та статусу авторизації
- Підключено store та `PersistGate` у `main.jsx`

### 📌 Примітки:
Це базова інтеграція, яка стане основою для подальшої розробки.  
Інші учасники команди вже можуть починати реалізацію функціоналу, що використовує збережений auth-стан.

