### PR TITLE
Fix/auth operations

### DIFF
--- a/src/components/Navigation/Navigation.jsx
+++ b/src/components/Navigation/Navigation.jsx
@@ -1,11 +1,20 @@
 import { Link } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { selectIsLoggedIn, selectUser } from '../../redux/auth/selectors';
+import { logOut } from '../../redux/auth/operations';
+import { useNavigate } from 'react-router-dom';
 import css from './Navigation.module.css';
 
 export default function Navigation() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
   const isAuthenticated = useSelector(selectIsLoggedIn);
   const user = useSelector(selectUser);
+
+  const handleLogout = () => {
+    dispatch(logOut());
+    navigate('/');
+  };
 
   return (
     <nav className={css.nav}>
@@ -18,7 +27,12 @@ export default function Navigation() {
           {isAuthenticated ? (
             <>
               <span className={css.userName}>Hello, {user?.name || 'User'}!</span>
-              <button className={css.logoutBtn}>Logout</button>
+              <button
+                className={css.logoutBtn}
+                onClick={handleLogout}
+              >
+                Logout
+              </button>
             </>
           ) : (
             <>

--- a/src/redux/auth/authSlice.js
+++ b/src/redux/auth/authSlice.js
@@ -65,13 +65,25 @@ const authSlice = createSlice({
 
         try {
           localStorage.removeItem('persist:auth');
-        } catch {
-          // Ignore errors
+          localStorage.removeItem('persist:recipes');
+        } catch (error) {
+          console.warn('Error clearing localStorage:', error);
         }
       })
-      .addCase(logOut.rejected, (state, action) => {
+      .addCase(logOut.rejected, state => {
+        state.user = { name: null, email: null };
+        state.token = null;
+        state.isLoggedIn = false;
         state.loading = false;
-        state.error = action.payload || 'Logout failed';
+        state.error = null;
+        state.refreshing = false;
+
+        try {
+          localStorage.removeItem('persist:auth');
+          localStorage.removeItem('persist:recipes');
+        } catch (error) {
+          console.warn('Error clearing localStorage:', error);
+        }
       })
       .addCase(refreshUser.pending, state => {
         state.refreshing = true;

--- a/src/redux/auth/operations.js
+++ b/src/redux/auth/operations.js
@@ -9,10 +9,12 @@ const setAuthHeader = value => {
 };
 
 const processAuthResponse = (data, credentials) => {
-  const token = data?.accessToken;
-  if (!token) throw new Error('No token found in response');
+  const token = data.accessToken;
+  if (!token) {
+    throw new Error('No token found in response');
+  }
 
-  const userData = data?.user || data?.data || data;
+  const userData = data.user;
 
   const user = {
     email: userData.email || credentials.email,
@@ -34,7 +36,14 @@ export const register = createAsyncThunk(
   'auth/register',
   async (credentials, thunkAPI) => {
     try {
-      return await performAuthRequest('/api/auth/register', credentials);
+      await axios.post('/api/auth/register', credentials);
+
+      const loginResponse = await axios.post('/api/auth/login', {
+        email: credentials.email,
+        password: credentials.password,
+      });
+
+      return processAuthResponse(loginResponse.data.data, credentials);
     } catch (error) {
       return thunkAPI.rejectWithValue(
         error.response?.data?.message || error.message || 'Registration failed'
@@ -47,7 +56,8 @@ export const logIn = createAsyncThunk(
   'auth/logIn',
   async (credentials, thunkAPI) => {
     try {
-      return await performAuthRequest('/api/auth/login', credentials);
+      const result = await performAuthRequest('/api/auth/login', credentials);
+      return result;
     } catch (error) {
       return thunkAPI.rejectWithValue(
         error.response?.data?.message || error.message

--- a/src/redux/auth/operations.js
+++ b/src/redux/auth/operations.js
@@ -57,20 +57,8 @@ export const logIn = createAsyncThunk(
 );
 
 export const logOut = createAsyncThunk('auth/logout', async () => {
+  await axios.post('/api/auth/logout');
   setAuthHeader('');
-
-  try {
-    localStorage.removeItem('persist:auth');
-    localStorage.removeItem('persist:recipes');
-  } catch {
-    // Ignore errors
-  }
-
-  try {
-    axios.post('/api/auth/logout').catch(() => {});
-  } catch {
-    // Ignore backend errors
-  }
 });
 
 export const refreshUser = createAsyncThunk(


### PR DESCRIPTION
## ✅ Спрощений код
### 🔧 Що було спрощено:
1. `processAuthResponse` - прибрано зайві перевірки:
 - Токен завжди в data.accessToken
 - Дані користувача завжди в data.user

2. `performAuthRequest` - прибрано зайві перевірки:
 -  Дані завжди в `response.data.data`

3. `register `- спрощено логіку:
 - Завжди виконуємо реєстрацію, потім логін
 - Прибрано перевірку статусу 201